### PR TITLE
Commands updated to allow parent bundle

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -56,7 +56,11 @@ abstract class AbstractCommand extends ContainerAwareCommand
     protected function getTargetBundle(InputInterface $input)
     {
         $bundleName = $input->getArgument('bundle');
+        $bundles = $this->getContainer()->get('kernel')->getBundle(
+            $bundleName,
+            false
+        );
 
-        return  $this->getContainer()->get('kernel')->getBundle($bundleName);
+        return end($bundles);
     }
 }

--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -61,6 +61,10 @@ abstract class AbstractCommand extends ContainerAwareCommand
             false
         );
 
-        return end($bundles);
+        foreach ($bundles as $bundle) {
+            if ($bundle->getName() == $bundleName) {
+                return $bundle;
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi,

We use that because our target bundle are parent with other and we need to migrate it.

Example:
  1 - Bundle A extends Bundle B
  2 - Migrations are in bundle B
  3 - But command "claroline:migration:upgrade 'Bundle B' --target=farthest" execute Bundle A migration

With this pull request, if we use this command "claroline:migration:upgrade 'Bundle B' --target=farthest" migrations of Bundle A will be executed.

Authors: @kziemianski and @Netmisa
