### PR TITLE
Avoid adding twig extension in constructor

### DIFF
--- a/Generator/Writer.php
+++ b/Generator/Writer.php
@@ -25,6 +25,7 @@ class Writer
     private $fileSystem;
     private $twigEnvironment;
     private $twigEngine;
+    private $hasSqlExtension = false;
 
     /**
      * Constructor.
@@ -42,7 +43,6 @@ class Writer
         $this->fileSystem = $fileSystem;
         $this->twigEnvironment = $environment;
         $this->twigEngine = $engine;
-        $this->twigEnvironment->addExtension(new SqlFormatterExtension());
     }
 
     /**
@@ -55,6 +55,11 @@ class Writer
      */
     public function writeMigrationClass(Bundle $bundle, $driverName, $version, array $queries)
     {
+        if (!$this->hasSqlExtension) {
+            $this->twigEnvironment->addExtension(new SqlFormatterExtension());
+            $this->hasSqlExtension = true;
+        }
+
         $targetDir = "{$bundle->getPath()}/Migrations/{$driverName}";
         $class = "Version{$version}";
         $namespace = "{$bundle->getNamespace()}\\Migrations\\{$driverName}";

--- a/Tests/Generator/WriterTest.php
+++ b/Tests/Generator/WriterTest.php
@@ -30,18 +30,6 @@ class WriterTest extends MockeryTestCase
         $this->fileSystem = m::mock('Symfony\Component\Filesystem\Filesystem');
     }
 
-    public function testWriterAddsTheSqlFormatterExtension()
-    {
-        $this->twigEnvironment->shouldReceive('addExtension')->once()->with(
-            m::on(
-                function ($argument) {
-                    return $argument instanceof SqlFormatterExtension;
-                }
-            )
-        );
-        $writer = new Writer($this->fileSystem, $this->twigEnvironment, $this->twigEngine);
-    }
-
     public function testWriteMigrationClasses()
     {
         vfsStream::setup(
@@ -59,7 +47,13 @@ class WriterTest extends MockeryTestCase
                 )
             )
         );
-        $this->twigEnvironment->shouldReceive('addExtension');
+        $this->twigEnvironment->shouldReceive('addExtension')->once()->with(
+            m::on(
+                function ($argument) {
+                    return $argument instanceof SqlFormatterExtension;
+                }
+            )
+        );
         $bundle = m::mock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundle->shouldReceive('getPath')->once()->andReturn(vfsStream::url('root') . '/bundle/path');
         $bundle->shouldReceive('getNamespace')->once()->andReturn('Bundle\Namespace');


### PR DESCRIPTION
Fixes the "Unable to register extension 'sql_formatter_extension' [...]" error...